### PR TITLE
update sui-tools's dockerfile

### DIFF
--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -55,6 +55,8 @@ COPY --from=builder /sui/target/release/sui-faucet /usr/local/bin
 COPY --from=builder /sui/target/release/stress /usr/local/bin
 COPY --from=builder /sui/target/release/sui-cluster-test /usr/local/bin
 
+RUN apt-get update && apt-get install -y libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
+
 ARG BUILD_DATE
 ARG GIT_REVISION
 LABEL build-date=$BUILD_DATE


### PR DESCRIPTION
fixed 'no CA certificates found'

> sui client active-address

thread 'main' panicked at 'no CA certificates found', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/hyper-rustls-0.23.0/src/config.rs:48:9 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace Aborted